### PR TITLE
fix logging.warn deprecation messages

### DIFF
--- a/patient_similarity/disease.py
+++ b/patient_similarity/disease.py
@@ -139,7 +139,7 @@ class Diseases:
                             phenotypes[hp_term] = freq
 
                         if old_freq != freq:
-                            logging.warn('Found conflicting frequencies ({}, {}) for same disease-phenotype: {}:{} - {} (taking larger)'.format(old_freq, freq, disease[0], disease[1], hp_term))
+                            logging.warning('Found conflicting frequencies ({}, {}) for same disease-phenotype: {}:{} - {} (taking larger)'.format(old_freq, freq, disease[0], disease[1], hp_term))
                     else:
                         phenotypes[hp_term] = freq
 

--- a/patient_similarity/hpoic.py
+++ b/patient_similarity/hpoic.py
@@ -96,10 +96,10 @@ class HPOIC:
                 raw_freq[term] += freq * prevalence
 
         if use_phenotype_frequency:
-            logging.warn('Used phenotype frequencies for {}/{} disease-phenotype associations'.format(n_phenotype_freqs_used, n_entries))
+            logging.warning('Used phenotype frequencies for {}/{} disease-phenotype associations'.format(n_phenotype_freqs_used, n_entries))
 
         if use_disease_prevalence:
-            logging.warn('Used disease prevalences for {}/{} diseases'.format(n_disease_prevalences_used, len(diseases)))
+            logging.warning('Used disease prevalences for {}/{} diseases'.format(n_disease_prevalences_used, len(diseases)))
 
         if patients:
             for patient in patients:
@@ -107,7 +107,7 @@ class HPOIC:
                     raw_freq[term] += 1
 
         if distribute_ic_to_leaves:
-            logger.warn('DISTRIBUTING WEIGHT TO LEAVES')
+            logger.warning('DISTRIBUTING WEIGHT TO LEAVES')
             q = [hpo.root]
 
             while q:


### PR DESCRIPTION
Fix deprecation messages due to the usage of logger.warn instead of logger.warning